### PR TITLE
Backport 8235654: JFR leak profiler should not trace through the StringTable

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/rootSetClosure.cpp
@@ -92,7 +92,6 @@ void RootSetClosure<Delegate>::process() {
   JvmtiExport::oops_do(this);
   SystemDictionary::oops_do(this);
   Management::oops_do(this);
-  StringTable::oops_do(this);
   AOTLoader::oops_do(this);
 }
 

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
@@ -173,13 +173,6 @@ bool ReferenceToRootClosure::do_management_roots() {
   return rlc.complete();
 }
 
-bool ReferenceToRootClosure::do_string_table_roots() {
-  assert(!complete(), "invariant");
-  ReferenceLocateClosure rlc(_callback, OldObjectRoot::_string_table, OldObjectRoot::_type_undetermined, NULL);
-  StringTable::oops_do(&rlc);
-  return rlc.complete();
-}
-
 bool ReferenceToRootClosure::do_aot_loader_roots() {
   assert(!complete(), "invariant");
   ReferenceLocateClosure rcl(_callback, OldObjectRoot::_aot, OldObjectRoot::_type_undetermined, NULL);
@@ -223,11 +216,6 @@ bool ReferenceToRootClosure::do_roots() {
   }
 
   if (do_management_roots()) {
-   _complete = true;
-    return true;
-  }
-
-  if (do_string_table_roots()) {
    _complete = true;
     return true;
   }

--- a/src/hotspot/share/jfr/leakprofiler/utilities/rootType.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/rootType.hpp
@@ -41,7 +41,6 @@ class OldObjectRoot : public AllStatic {
     _management,
     _jvmti,
     _code_cache,
-    _string_table,
     _aot,
     _number_of_systems
   };

--- a/src/hotspot/share/jfr/leakprofiler/utilities/rootType.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/utilities/rootType.hpp
@@ -77,8 +77,6 @@ class OldObjectRoot : public AllStatic {
         return "JVMTI";
       case _code_cache:
         return "Code Cache";
-      case _string_table:
-        return "String Table";
       case _aot:
         return "AOT";
       default:


### PR DESCRIPTION
Original JBS Issue: https://bugs.openjdk.org/browse/JDK-8235654
Original Commit : https://hg.openjdk.org/jdk/jdk/rev/e2232c851cdb

- [x]  Backport

Description:
This PR contains the backport code for removing the String table root tracing from root snapshot in leak profiler. The JFR leak profiler finds strong reference chains to object samples.

Differences from Original Commit:
1)  https://hg.openjdk.org/jdk/jdk/file/e2232c851cdb/src/hotspot/share/classfile/stringTable.cpp:
    Could not delete as this below method has been used by  psMarkSweep.cpp, psParallelCompact.cpp, genCollectedHeap.cpp
        -void StringTable::oops_do(OopClosure* f) {
        -  assert(f != NULL, "No closure");
        -  OopStorageSet::string_table_weak()->oops_do(f);
        -}
2) https://hg.openjdk.org/jdk/jdk/file/e2232c851cdb/src/hotspot/share/classfile/stringTable.hpp: 
     Could not delete: "-  static void oops_do(OopClosure* f);" as it has been implemented/ used in StringTable.cpp
      
Testing:

- [x]  All existing tier1 and JFR test pass locally
- [x]  PR build is succeeded.