### PR TITLE
Moved two patches to the Upstreamed section

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -6,10 +6,10 @@
 # test, for instance).
 #
 # For each patch branch, there  will be a file in the ms-patches/ folder that has the
-# name of the branch in it's file name (for example, this file follows that pattern).
+# name of the branch in its file name (for example, this file follows that pattern).
 # The file is the source data for the README file we generate in the release branch, and
 # contains such information as Microsoft dev responsible for the patch, the original
-# author(s), associated JEP- or JBS- issue, and a summary of the patches' purpose.
+# author(s), associated JEP- or JBS- issue, and a summary of the patch's purpose.
 
 
 ## Active Patches
@@ -20,11 +20,11 @@ active-patches:
   - ms-patches/JFR-Backport-8217089-LazyInstallOsIForImprovedPerf
   - ms-patches/JFR-command-duration-output
   - ms-patches/JFR-deoptimization-event
-  - ms-patches/JFR-FileIOStatisticsEvents
   - ms-patches/JFR-provide-object-age
   - ms-patches/md5-intrinsics
   - ms-patches/off-by-1-AbsPathInImage-fix
   - ms-patches/reduced-allocation-merges
+  - ms-patches/sst
 
 
 ## Upstreamed Patches

--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -23,7 +23,7 @@ active-patches:
   - ms-patches/JFR-provide-object-age
   - ms-patches/md5-intrinsics
   - ms-patches/off-by-1-AbsPathInImage-fix
-  - ms-patches/reduced-allocation-merges
+  - ms-patches/reduce-allocation-merges
   - ms-patches/sst
 
 

--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -16,8 +16,6 @@
 # Patches that we are applying to each release.
 active-patches:
 # - ms-patches/microsoft-patch-index // this patch branch is required for all releases
-  - ms-patches/8303607-ncrypt-leak-fix
-  - ms-patches/Backport-JDK-8305763
   - ms-patches/JFR-Backport-8216995-CleanupJFRCmdln
   - ms-patches/JFR-Backport-8217089-LazyInstallOsIForImprovedPerf
   - ms-patches/JFR-command-duration-output
@@ -29,20 +27,19 @@ active-patches:
   - ms-patches/reduced-allocation-merges
 
 
-## Upsteamed Patches
+## Upstreamed Patches
 # Patches that we are no longer applying to our releases, as they
 # have been upstreamed and are part of the official OpenJDK sources.
 #
 # upstreamed-patches: 
-  # - ms-patches/abandoned-feature-branch-name-1
-  # ...
-  # - ms-patches/abandoned-feature-branch-name-N
+  - ZZ_archive/ms-patches/8303607-ncrypt-leak-fix
+  - ZZ_archive/ms-patches/Backport-JDK-8305763-URIParsing
 
 
 # Patches that we are no longer applying to our releases as they have
 # been abandoned for one reason or another.
 #
 # abandoned-patches:
-  # - ms-patches/abandoned-feature-branch-name-1
+  # - ZZ_archive/ms-patches/abandoned-feature-branch-name-1
   # ...
-  # - ms-patches/abandoned-feature-branch-name-N
+  # - ZZ_archive/ms-patches/abandoned-feature-branch-name-N


### PR DESCRIPTION
Two patches have been merged upstream, so I'm moving them to the Upstreamed section. Also fixed a typo and updated the comments to indicate we're prefixing the inactive patches by ZZ_archive.