### PR TITLE
1922374: Create JFR-Backport-8216995-CleanupJFRCmdln.yml metadata file

### DIFF
--- a/ms-patches/JFR-Backport-8216995-CleanupJFRCmdln.yml
+++ b/ms-patches/JFR-Backport-8216995-CleanupJFRCmdln.yml
@@ -1,0 +1,14 @@
+title: JFR-Backport-Clean up JFR CmdLine 
+- work_item: 1713229
+- jbs_bug: JDK-8216995
+- author: kthatipally
+- owner: kthatipally
+- contributors:
+  - kthatipally
+- details:
+  - Cleanup JFR commandLine processing - JfrRecorder::is_disabled is called early during bootstrap and uses JVMFlag::find_flag directly to check whether the -XX:-FlightRecorder has been set on the command line. 
+  - Using the FLAG_IS_CMDLINE macro from global_extensions have the same effect cleans it up and might avoid a linear scan.
+  - This is a backport of the original comit "https://hg.openjdk.org/jdk/jdk/rev/65a1d49d1718" to JDK 11.
+  - Differences with original commit - In the enable () method - Line 63, There is an additional validation check for the flight recorder value. 
+    If the FlightRecorder value is already set to true, then the FLAG_SET_MGMT(bool, FlightRecorder, true); is skipped.   
+- release_note: Backport - Cleanup JFR commandLine.

--- a/ms-patches/JFR-Backport-8216995-CleanupJFRCmdln.yml
+++ b/ms-patches/JFR-Backport-8216995-CleanupJFRCmdln.yml
@@ -8,7 +8,7 @@ title: JFR-Backport-Clean up JFR CmdLine
 - details:
   - Cleanup JFR commandLine processing - JfrRecorder::is_disabled is called early during bootstrap and uses JVMFlag::find_flag directly to check whether the -XX:-FlightRecorder has been set on the command line. 
   - Using the FLAG_IS_CMDLINE macro from global_extensions have the same effect cleans it up and might avoid a linear scan.
-  - This is a backport of the original comit "https://hg.openjdk.org/jdk/jdk/rev/65a1d49d1718" to JDK 11.
+  - This is a backport of the original commit "https://hg.openjdk.org/jdk/jdk/rev/65a1d49d1718" to JDK 11.
   - Differences with original commit - In the enable () method - Line 63, There is an additional validation check for the flight recorder value. 
     If the FlightRecorder value is already set to true, then the FLAG_SET_MGMT(bool, FlightRecorder, true); is skipped.   
-- release_note: Backport - Cleanup JFR commandLine.
+- release_note: Clean up JFR Command Line.


### PR DESCRIPTION
This PR contains a new metadata file in the path ms-patches/JFR-Backport-8216995-CleanupJFRCmdln.yml (https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1922374)

**_Template for the yml file:_**
Proper title for the patch.
Any associated JBS bug numbers or AzDO work items.
Original author of the patch.
Person currently responsible for the patch (alias on GitHub).
Any other contributors to the patch.
Any further details that are useful for the author, for future maintainers of the patch, and for the community.
A section entitled “Release Notes” which includes a description of the patch suitable for automatically including in the release notes of the Microsoft Build of OpenJDK. There may be some overlap between this section and the ones above (where sufficient, some of the above may only be included in this section).

**_Details about the ms-patches feature branch:_**
Branch name: https://github.com/microsoft/openjdk-jdk11u/tree/ms-patches/JFR-Backport-8216995-CleanupJFRCmdln 
PR: https://github.com/microsoft/openjdk-jdk11u/pull/11
Azdo Work item: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1713229 