### PR TITLE
1922377: Create JFR-Backport-8217089-LazyInstallOsIForImprovedPerf-metadata.yml metadata file

### DIFF
--- a/ms-patches/JFR-Backport-8217089-LazyInstallOsIForImprovedPerf.yml
+++ b/ms-patches/JFR-Backport-8217089-LazyInstallOsIForImprovedPerf.yml
@@ -10,4 +10,4 @@ title: JFR-Backport-8217089-Lazy install OS Interface for improved startup perfo
   - These changes lets the periodic event requestor thread install os interface components when requested instead of doing it eagerly as part of startup by the initial thread.
   - This is a backport of the original commit "https://hg.openjdk.org/jdk/jdk/rev/e63a624da347" to JDK 11.
   - Clean backport, no differences with original commit.
-- release_note: Backport - Lazy install OS interface components in JFR for improved startup performance
+- release_note: Lazy install os interface components for improved startup

--- a/ms-patches/JFR-Backport-8217089-LazyInstallOsIForImprovedPerf.yml
+++ b/ms-patches/JFR-Backport-8217089-LazyInstallOsIForImprovedPerf.yml
@@ -1,0 +1,13 @@
+title: JFR-Backport-8217089-Lazy install OS Interface for improved startup performance
+- work_item: 1713230
+- jbs_bug: JDK-8217089
+- author: kthatipally
+- owner: kthatipally
+- contributors:
+  - kthatipally
+- details:
+  - code modifications to lazy install os interface components for improved startup.
+  - These changes lets the periodic event requestor thread install os interface components when requested instead of doing it eagerly as part of startup by the initial thread.
+  - This is a backport of the original commit "https://hg.openjdk.org/jdk/jdk/rev/e63a624da347" to JDK 11.
+  - Clean backport, no differences with original commit.
+- release_note: Backport - Lazy install OS interface components in JFR for improved startup performance


### PR DESCRIPTION
This PR contains a new metadata file in the path ms-patches/JFR-Backport-8217089-LazyInstallOsIForImprovedPerf.yml (https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1922377)

_**Template for the yml file:**_
Proper title for the patch.
Any associated JBS bug numbers or AzDO work items.
Original author of the patch.
Person currently responsible for the patch (alias on GitHub).
Any other contributors to the patch.
Any further details that are useful for the author, for future maintainers of the patch, and for the community.
A section entitled “Release Notes” which includes a description of the patch suitable for automatically including in the release notes of the Microsoft Build of OpenJDK. There may be some overlap between this section and the ones above (where sufficient, some of the above may only be included in this section).

**_Details about the ms-patches feature branch:_**
Branch name: https://github.com/microsoft/openjdk-jdk11u/tree/ms-patches/JFR-Backport-8217089-LazyInstallOsIForImprovedPerf
PR: https://github.com/microsoft/openjdk-jdk11u/pull/12
Azdo Work item: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1713230