### PR TITLE
1922382: Create JFR-command-duration-output.yml metadata file

### DIFF
--- a/ms-patches/JFR-command-duration-output.yml
+++ b/ms-patches/JFR-command-duration-output.yml
@@ -1,0 +1,12 @@
+title: JFR-Backport-Make JFR command duration output more user friendly
+- work_item: 1644701
+- jbs_bug: JDK-8232594
+- author: aamarsh
+- owner: kthatipally
+- contributors:
+  - aamarsh
+- details:
+  - Add utility methods to convert time format to more user friendly format.
+  - This is a backport of the original commit "https://hg.openjdk.org/jdk/jdk/rev/43eee1237934" to JDK 11.
+  - Clean backport, no differences with original commit.
+- release_note: Backport - Make JFR command duration output more user friendly

--- a/ms-patches/JFR-command-duration-output.yml
+++ b/ms-patches/JFR-command-duration-output.yml
@@ -9,4 +9,4 @@ title: JFR-Backport-Make JFR command duration output more user friendly
   - Add utility methods to convert time format to more user friendly format.
   - This is a backport of the original commit "https://hg.openjdk.org/jdk/jdk/rev/43eee1237934" to JDK 11.
   - Clean backport, no differences with original commit.
-- release_note: Backport - Make JFR command duration output more user friendly
+- release_note: Make the output of the JFR command duration more user friendly.


### PR DESCRIPTION
This PR contains a new metadata file in the path ms-patches/JFR-command-duration-output.yml (https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1922382)

_**Template for the yml file:**_
Proper title for the patch.
Any associated JBS bug numbers or AzDO work items.
Original author of the patch.
Person currently responsible for the patch (alias on GitHub).
Any other contributors to the patch.
Any further details that are useful for the author, for future maintainers of the patch, and for the community.
A section entitled “Release Notes” which includes a description of the patch suitable for automatically including in the release notes of the Microsoft Build of OpenJDK. There may be some overlap between this section and the ones above (where sufficient, some of the above may only be included in this section).

_**Details about the ms-patches feature branch:**_
Branch name: [microsoft/openjdk-jdk11u at ms-patches/JFR-command-duration-output (github.com)](https://github.com/microsoft/openjdk-jdk11u/tree/ms-patches/JFR-command-duration-output)
PR: [Backport 8232594: Make the output of the JFR command duration more user friendly by aamarsh · Pull Request #7 · microsoft/openjdk-jdk11u (github.com)](https://github.com/microsoft/openjdk-jdk11u/pull/7)
Azdo Work item: [Task 1644701 Make the output of the JFR command duration more user friendly (visualstudio.com)](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1644701)