### PR TITLE
1922387: Create JFR-deoptimization-event.yml metadata file

### DIFF
--- a/ms-patches/JFR-deoptimization-event.yml
+++ b/ms-patches/JFR-deoptimization-event.yml
@@ -10,4 +10,4 @@ title: JFR-Backport-Add support for the deoptimization events
   - This is a backport of the original commit "https://hg.openjdk.org/jdk/jdk/rev/de99f7acea70" to JDK 11.
   - Modifications were made to be compatible with JDK 11, including adding necessary includes, reordering arguments in Atomic::cmpxchg, reintroducing and setting require_safepoint to false in register_serializer, and adjusting method calls in jfrTypeManager.cpp for compatibility.
   - More details can be found in the PR (https://github.com/microsoft/openjdk-jdk11u/pull/6)
-- release_note: Backport - Add support for new JFR deoptimization events
+- release_note: Add support for new JFR deoptimization events

--- a/ms-patches/JFR-deoptimization-event.yml
+++ b/ms-patches/JFR-deoptimization-event.yml
@@ -1,0 +1,13 @@
+title: JFR-Backport-Add support for the deoptimization events
+- work_item: 1644707
+- jbs_bug: JDK-8216041
+- author: aamarsh
+- owner: kthatipally
+- contributors:
+  - aamarsh
+- details:
+  - Add support for new JFR deoptimization events.
+  - This is a backport of the original commit "https://hg.openjdk.org/jdk/jdk/rev/de99f7acea70" to JDK 11.
+  - Modifications were made to be compatible with JDK 11, including adding necessary includes, reordering arguments in Atomic::cmpxchg, reintroducing and setting require_safepoint to false in register_serializer, and adjusting method calls in jfrTypeManager.cpp for compatibility.
+  - More details can be found in the PR (https://github.com/microsoft/openjdk-jdk11u/pull/6)
+- release_note: Backport - Add support for new JFR deoptimization events


### PR DESCRIPTION
This PR contains a new metadata file in the path ms-patches/JFR-deoptimization-event.yml (https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1922387)

**_Template for the yml file:_**
Proper title for the patch.
Any associated JBS bug numbers or AzDO work items.
Original author of the patch.
Person currently responsible for the patch (alias on GitHub).
Any other contributors to the patch.
Any further details that are useful for the author, for future maintainers of the patch, and for the community.
A section entitled “Release Notes” which includes a description of the patch suitable for automatically including in the release notes of the Microsoft Build of OpenJDK. There may be some overlap between this section and the ones above (where sufficient, some of the above may only be included in this section).

_**Details about the ms-patches feature branch:**_
Branch name: [microsoft/openjdk-jdk11u at ms-patches/JFR-deoptimization-event (github.com)](https://github.com/microsoft/openjdk-jdk11u/tree/ms-patches/JFR-deoptimization-event)
PR: [Backport 8216041: [Event Request] - Deoptimization by aamarsh · Pull Request #6 · microsoft/openjdk-jdk11u (github.com)](https://github.com/microsoft/openjdk-jdk11u/pull/6)
JBS Bug: [[JDK-8216041] [Event Request] - Deoptimization - Java Bug System (openjdk.org)](https://bugs.openjdk.org/browse/JDK-8216041)
Original Commit: [jdk/jdk: de99f7acea70 (openjdk.org)](https://hg.openjdk.org/jdk/jdk/rev/de99f7acea70)
Work item: [Task 1644707 [Event Request] - Deoptimization (visualstudio.com)](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1644707)