### PR TITLE
Updating ms-patches/reduce-allocation-merges with latest fixes merged in JDK Tip

### DIFF
--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -241,6 +241,14 @@ ObjectValue* ObjectMergeValue::select(frame& fr, RegisterMap& reg_map) {
   }
 }
 
+Handle ObjectMergeValue::value() const {
+  if (_selected != NULL) {
+    return _selected->value();
+  } else {
+    return Handle();
+  }
+}
+
 void ObjectMergeValue::read_object(DebugInfoReadStream* stream) {
   _selector = read_from(stream);
   _merge_pointer = read_from(stream);

--- a/src/hotspot/share/code/debugInfo.hpp
+++ b/src/hotspot/share/code/debugInfo.hpp
@@ -206,7 +206,7 @@ public:
   ScopeValue*                 field_at(int i) const           { ShouldNotReachHere(); return NULL; }
   int                         field_size()                    { ShouldNotReachHere(); return -1; }
 
-  Handle                      value() const                   { assert(_selected != NULL, "Should call select() first."); return _selected->value(); }
+  Handle                      value() const;
   void                        set_value(oop value)            { assert(_selected != NULL, "Should call select() first."); _selected->set_value(value); }
 
   // Serialization of debugging information

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,7 +239,8 @@ void PhaseMacroExpand::eliminate_gc_barrier(Node* p2x) {
 // Search for a memory operation for the specified memory slice.
 static Node *scan_mem_chain(Node *mem, int alias_idx, int offset, Node *start_mem, Node *alloc, PhaseGVN *phase) {
   Node *orig_mem = mem;
-  Node *alloc_mem = alloc->in(TypeFunc::Memory);
+  Node *alloc_mem = alloc->as_Allocate()->proj_out_or_null(TypeFunc::Memory, /*io_use:*/false);
+  assert(alloc_mem != NULL, "Allocation without a memory projection.");
   const TypeOopPtr *tinst = phase->C->get_adr_type(alias_idx)->isa_oopptr();
   while (true) {
     if (mem == alloc_mem || mem == start_mem ) {
@@ -438,7 +439,8 @@ Node *PhaseMacroExpand::value_from_mem_phi(Node *mem, BasicType ft, const Type *
     return NULL; // Give up: phi tree too deep
   }
   Node *start_mem = C->start()->proj_out_or_null(TypeFunc::Memory);
-  Node *alloc_mem = alloc->in(TypeFunc::Memory);
+  Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory, /*io_use:*/false);
+  assert(alloc_mem != NULL, "Allocation without a memory projection.");
 
   uint length = mem->req();
   GrowableArray <Node *> values(length, length, NULL, false);
@@ -527,7 +529,8 @@ Node *PhaseMacroExpand::value_from_mem(Node *sfpt_mem, Node *sfpt_ctl, BasicType
   int offset = adr_t->offset();
   Node *start_mem = C->start()->proj_out_or_null(TypeFunc::Memory);
   Node *alloc_ctrl = alloc->in(TypeFunc::Control);
-  Node *alloc_mem = alloc->in(TypeFunc::Memory);
+  Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory, /*io_use:*/false);
+  assert(alloc_mem != NULL, "Allocation without a memory projection.");
   Arena *a = Thread::current()->resource_area();
   VectorSet visited(a);
 

--- a/src/hotspot/share/opto/multnode.cpp
+++ b/src/hotspot/share/opto/multnode.cpp
@@ -63,6 +63,16 @@ ProjNode* MultiNode::proj_out_or_null(uint which_proj) const {
   return NULL;
 }
 
+ProjNode* MultiNode::proj_out_or_null(uint which_proj, bool is_io_use) const {
+  for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
+    ProjNode* proj = fast_out(i)->isa_Proj();
+    if (proj != NULL && (proj->_con == which_proj) && (proj->_is_io_use == is_io_use)) {
+      return proj;
+    }
+  }
+  return NULL;
+}
+
 // Get a named projection
 ProjNode* MultiNode::proj_out(uint which_proj) const {
   ProjNode* p = proj_out_or_null(which_proj);

--- a/src/hotspot/share/opto/multnode.hpp
+++ b/src/hotspot/share/opto/multnode.hpp
@@ -47,6 +47,7 @@ public:
   virtual Node *match( const ProjNode *proj, const Matcher *m );
   virtual uint ideal_reg() const { return NotAMachineReg; }
   ProjNode* proj_out(uint which_proj) const; // Get a named projection
+  ProjNode* proj_out_or_null(uint which_proj, bool is_io_use) const;
   ProjNode* proj_out_or_null(uint which_proj) const;
 
 };

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -864,6 +864,30 @@ void Compile::Process_OopMap_Node(MachNode *mach, int current_offset) {
           }
           scval = sv;
         }
+      } else if (obj_node->is_SafePointScalarMerge()) {
+        SafePointScalarMergeNode* smerge = obj_node->as_SafePointScalarMerge();
+        ObjectMergeValue* mv = (ObjectMergeValue*) Compile::sv_for_node_id(objs, smerge->_idx);
+
+        if (mv == NULL) {
+          GrowableArray<ScopeValue*> deps;
+
+          int merge_pointer_idx = smerge->merge_pointer_idx(youngest_jvms);
+          (void)FillLocArray(0, sfn, sfn->in(merge_pointer_idx), &deps, objs);
+          assert(deps.length() == 1, "missing value");
+
+          int selector_idx = smerge->selector_idx(youngest_jvms);
+          (void)FillLocArray(1, NULL, sfn->in(selector_idx), &deps, NULL);
+          assert(deps.length() == 2, "missing value");
+
+          mv = new ObjectMergeValue(smerge->_idx, deps.at(0), deps.at(1));
+	  Compile::set_sv_for_object_node(objs, mv);
+
+          for (uint i = 1; i < smerge->req(); i++) {
+            Node* obj_node = smerge->in(i);
+            (void)FillLocArray(mv->possible_objects()->length(), sfn, obj_node, mv->possible_objects(), objs);
+          }
+        }
+        scval = mv;
       } else if (!obj_node->is_Con()) {
         OptoReg::Name obj_reg = _regalloc->get_reg_first(obj_node);
         if( obj_node->bottom_type()->base() == Type::NarrowOop ) {

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8319784
+ * @summary Check that the JVM is able to dump the heap even when there are ReduceAllocationMerge in the scope.
+ * @library /test/lib /
+ * @run main/othervm compiler.c2.TestReduceAllocationAndHeapDump
+ */
+
+package compiler.c2;
+
+import java.io.File;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestReduceAllocationAndHeapDump {
+    public static void main(String[] args) throws Exception {
+        File dumpDirectory = new File("dumps");
+
+        try {
+            if (!dumpDirectory.exists()) {
+                dumpDirectory.mkdir();
+            }
+
+            String[] dumperArgs = {
+                "-server",
+                "-XX:CompileThresholdScaling=0.01",
+                "-XX:+HeapDumpAfterFullGC",
+                "-XX:HeapDumpPath=" + dumpDirectory.getAbsolutePath(),
+                "-XX:CompileCommand=compileonly,compiler.c2.HeapDumper::testIt",
+                "-XX:CompileCommand=exclude,compiler.c2.HeapDumper::dummy",
+                HeapDumper.class.getName()
+            };
+
+            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(dumperArgs);
+            Process p = pb.start();
+            OutputAnalyzer out = new OutputAnalyzer(p);
+
+            if (out.getExitValue() != 0) {
+                throw new IllegalStateException("Subprocess finished with non-zero exit code.");
+            }
+        } finally {
+            File[] files = dumpDirectory.listFiles((dir, name) -> name.endsWith(".hprof"));
+
+            for (File file : files) {
+                System.out.println("Deleting " + file.getAbsolutePath());
+                file.delete();
+            }
+        }
+    }
+}
+
+class HeapDumper {
+    public static Point p = new Point(0);
+
+    public static void main(String[] args) throws Exception {
+        for (int i = 0; i < 5000; i++) {
+            testIt(i);
+        }
+    }
+
+    public static void testIt(int i) throws Exception {
+        Point p = (i % 2 == 0) ? new Point(i) : new Point(i);
+
+        dummy(i);
+
+        if (i < 5000) {
+            dummy(i);
+        } else {
+            dummy(p.x + i);
+        }
+    }
+
+    public static void dummy(int x) {
+        if (x > 4900) {
+            System.gc();
+        }
+    }
+}
+
+// Helper class
+class Point {
+    public int x;
+
+    public Point(int xx) {
+        this.x = xx;
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -44,17 +44,13 @@ public class TestReduceAllocationAndHeapDump {
                 dumpDirectory.mkdir();
             }
 
-            String[] dumperArgs = {
-                "-server",
-                "-XX:CompileThresholdScaling=0.01",
-                "-XX:+HeapDumpAfterFullGC",
-                "-XX:HeapDumpPath=" + dumpDirectory.getAbsolutePath(),
-                "-XX:CompileCommand=compileonly,compiler.c2.HeapDumper::testIt",
-                "-XX:CompileCommand=exclude,compiler.c2.HeapDumper::dummy",
-                HeapDumper.class.getName()
-            };
-
-            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(dumperArgs);
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-server",
+                                                                      "-XX:CompileThresholdScaling=0.01",
+                                                                      "-XX:+HeapDumpAfterFullGC",
+                                                                      "-XX:HeapDumpPath=" + dumpDirectory.getAbsolutePath(),
+                                                                      "-XX:CompileCommand=compileonly,compiler.c2.HeapDumper::testIt",
+                                                                      "-XX:CompileCommand=exclude,compiler.c2.HeapDumper::dummy",
+                                                                      HeapDumper.class.getName());
             Process p = pb.start();
             OutputAnalyzer out = new OutputAnalyzer(p);
 

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndMemoryLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndMemoryLoop.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8322854
+ * @summary Check that the RAM optimization works when there is a memory loop.
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndMemoryLoop*::test*
+ *                   -XX:-TieredCompilation -Xbatch
+ *                   compiler.c2.TestReduceAllocationAndMemoryLoop
+ */
+
+package compiler.c2;
+
+public class TestReduceAllocationAndMemoryLoop {
+    public static void main(String[] args) throws Exception {
+        // Warmup
+        for (int i = 0; i < 50_000; ++i) {
+            test(false, 10);
+        }
+
+        // Trigger deoptimization
+        MyClass obj = test(false, 11);
+        if (obj.val != 42) {
+            throw new RuntimeException("Test failed, val = " + obj.val);
+        }
+    }
+
+    static class MyClass {
+        final int val;
+
+        public MyClass(int val) {
+            this.val = val;
+        }
+    }
+
+    public static MyClass test(boolean alwaysFalse, int limit) {
+        for (int i = 0; ; ++i) {
+            MyClass obj = new MyClass(42);
+            if (alwaysFalse || i > 10) {
+                return obj;
+            }
+            if (i == limit) {
+              return null;
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8323190
+ * @summary C2 Segfaults during code generation because of unhandled SafePointScalarMerge monitor debug info.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xcomp -XX:+ReduceAllocationMerges TestInvalidLocation
+ */
+
+public class TestInvalidLocation {
+    static boolean var2 = true;
+    static double[] var4 = new double[1];
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10; i++) {
+            System.out.println(test());
+        }
+    }
+
+    static Class0 test() {
+        double[] var14;
+        double var3;
+        StringBuilder var1 = new StringBuilder();
+        Class0 var0 = Class1.Class1_sfield0;
+        synchronized (var2 ? new StringBuilder() : var1) {
+            var14 = var4;
+            for (int i0 = 0; i0 < var0.Class0_field0.length && i0 < var14.length; i0 = 1) {
+                var3 = var14[i0];
+            }
+        }
+        return var0;
+    }
+
+    static class Class0 {
+        double[] Class0_field0;
+        Class0() {
+            Class0_field0 = new double[] { 85.42200639495138 };
+        }
+    }
+
+    class Class1 {
+        static Class0 Class1_sfield0 = new Class0();
+    }
+}


### PR DESCRIPTION
Four fixes have been integrated on JDK Tip relating to RAM optimization:

- https://github.com/openjdk/jdk/pull/17562
- https://github.com/openjdk/jdk/pull/17333
- https://github.com/openjdk/jdk/pull/16622
- https://github.com/openjdk/jdk/pull/17469

The patch from the last PR above isn't included in this backport because it's a fix on a test where the test itself isn't present in this repository -- because it would require backporting/copying a large test infrastructure. All other fixes are included in this PR as separate commits.

*Notes:*
- As part of the backport this _new_ method was added to multnode.cpp: ProjNode* MultiNode::proj_out_or_null(uint which_proj, bool is_io_use)
- The `sv_for_node_id` is in the Compile class in this version of JDK.