### PR TITLE
8329348: Fix Windows AArch64 'No rule to make target .../windows/conf/tzmappings' error

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -105,44 +105,39 @@ ALL_TARGETS += generate-exported-symbols
 
 ################################################################################
 # Gensrc targets, generating source before java compilation can be done
-#
-# When creating a BUILDJDK, the java targets have already been built and copied
-# into the buildjdk so no need to generate sources.
-ifneq ($(CREATING_BUILDJDK), true)
-  $(eval $(call DeclareRecipesForPhase, GENSRC, \
-      TARGET_SUFFIX := gensrc-src, \
-      FILE_PREFIX := Gensrc, \
-      MAKE_SUBDIR := gensrc, \
-      CHECK_MODULES := $(ALL_MODULES), \
-  ))
+$(eval $(call DeclareRecipesForPhase, GENSRC, \
+    TARGET_SUFFIX := gensrc-src, \
+    FILE_PREFIX := Gensrc, \
+    MAKE_SUBDIR := gensrc, \
+    CHECK_MODULES := $(ALL_MODULES), \
+))
 
-  $(foreach m, $(GENSRC_MODULES), $(eval $m-gensrc: $m-gensrc-src))
+$(foreach m, $(GENSRC_MODULES), $(eval $m-gensrc: $m-gensrc-src))
 
-  LANGTOOLS_GENSRC_TARGETS := $(filter $(addsuffix -%, $(LANGTOOLS_MODULES)), $(GENSRC_TARGETS))
-  INTERIM_LANGTOOLS_GENSRC_TARGETS := $(filter $(addsuffix -%, \
-      $(INTERIM_LANGTOOLS_BASE_MODULES)), $(GENSRC_TARGETS))
-  HOTSPOT_GENSRC_TARGETS := $(filter $(addsuffix -%, $(HOTSPOT_MODULES)), $(GENSRC_TARGETS))
-  JDK_GENSRC_TARGETS := $(filter-out $(LANGTOOLS_GENSRC_TARGETS) \
-      $(HOTSPOT_GENSRC_TARGETS), $(GENSRC_TARGETS))
+LANGTOOLS_GENSRC_TARGETS := $(filter $(addsuffix -%, $(LANGTOOLS_MODULES)), $(GENSRC_TARGETS))
+INTERIM_LANGTOOLS_GENSRC_TARGETS := $(filter $(addsuffix -%, \
+    $(INTERIM_LANGTOOLS_BASE_MODULES)), $(GENSRC_TARGETS))
+HOTSPOT_GENSRC_TARGETS := $(filter $(addsuffix -%, $(HOTSPOT_MODULES)), $(GENSRC_TARGETS))
+JDK_GENSRC_TARGETS := $(filter-out $(LANGTOOLS_GENSRC_TARGETS) \
+    $(HOTSPOT_GENSRC_TARGETS), $(GENSRC_TARGETS))
 
-  GENSRC_MODULEINFO_MODULES := $(ALL_MODULES)
-  GENSRC_MODULEINFO_TARGETS := $(addsuffix -gensrc-moduleinfo, \
-      $(GENSRC_MODULEINFO_MODULES))
+GENSRC_MODULEINFO_MODULES := $(ALL_MODULES)
+GENSRC_MODULEINFO_TARGETS := $(addsuffix -gensrc-moduleinfo, \
+    $(GENSRC_MODULEINFO_MODULES))
 
-  GENSRC_MODULES := $(GENSRC_MODULEINFO_MODULES)
-  GENSRC_TARGETS += $(sort $(GENSRC_MODULEINFO_TARGETS) \
-      $(addsuffix -gensrc, $(GENSRC_MODULES)))
+GENSRC_MODULES := $(GENSRC_MODULEINFO_MODULES)
+GENSRC_TARGETS += $(sort $(GENSRC_MODULEINFO_TARGETS) \
+    $(addsuffix -gensrc, $(GENSRC_MODULES)))
 
-  define DeclareModuleInfoRecipe
-    $1-gensrc-moduleinfo:
+define DeclareModuleInfoRecipe
+  $1-gensrc-moduleinfo:
 	+($(CD) $(TOPDIR)/make && $(MAKE) $(MAKE_ARGS) \
 	    -f gensrc/GensrcModuleInfo.gmk MODULE=$1)
 
-    $1-gensrc: $1-gensrc-moduleinfo
-  endef
+  $1-gensrc: $1-gensrc-moduleinfo
+endef
 
-  $(foreach m, $(GENSRC_MODULEINFO_MODULES), $(eval $(call DeclareModuleInfoRecipe,$m)))
-endif
+$(foreach m, $(GENSRC_MODULEINFO_MODULES), $(eval $(call DeclareModuleInfoRecipe,$m)))
 
 ALL_TARGETS += $(GENSRC_TARGETS)
 
@@ -750,11 +745,7 @@ else
 
   # Declare dependencies from <module>-lib to <module>-java
   # Skip modules that do not have java source.
-  # When creating a BUILDJDK, the java compilation has already been done by the
-  # normal build and copied in.
-  ifneq ($(CREATING_BUILDJDK), true)
-    $(foreach m, $(filter $(JAVA_MODULES), $(LIBS_MODULES)), $(eval $m-libs: $m-java))
-  endif
+  $(foreach m, $(filter $(JAVA_MODULES), $(LIBS_MODULES)), $(eval $m-libs: $m-java))
 
   # Declare dependencies from all other <module>-lib to java.base-lib
   $(foreach t, $(filter-out java.base-libs, $(LIBS_TARGETS)), \


### PR DESCRIPTION
***DO NOT MERGE***

Fixes [JDK-8329348](https://bugs.openjdk.org/browse/JDK-8329348).

From [JDK-8217739](https://bugs.openjdk.org/browse/JDK-8217739): "the default behavior is to create a BuildJDK on the fly when cross compiling, but for efficiency reasons, we try to reuse as much as possible of the JDK built for the target. One such reuse is all class files as they were assumed to be equivalent. We now have an example of where they aren't. I think the simplest solution to this is to stop reusing all of java.base classes and let the BuildJDK build gensrc and compile those classes separately."

This fix uses the same approach as [JDK-8217739](https://bugs.openjdk.org/browse/JDK-8217739) by removing checks for CREATING_BUILDJDK to ensure that the GENSRC_TARGETS are built unconditionally.