### PR TITLE
Fix Windows AArch64 'No rule to make target .../windows/conf/tzmappings' error

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -108,7 +108,6 @@ ALL_TARGETS += generate-exported-symbols
 #
 # When creating a BUILDJDK, the java targets have already been built and copied
 # into the buildjdk so no need to generate sources.
-ifneq ($(CREATING_BUILDJDK), true)
   $(eval $(call DeclareRecipesForPhase, GENSRC, \
       TARGET_SUFFIX := gensrc-src, \
       FILE_PREFIX := Gensrc, \
@@ -142,7 +141,7 @@ ifneq ($(CREATING_BUILDJDK), true)
   endef
 
   $(foreach m, $(GENSRC_MODULEINFO_MODULES), $(eval $(call DeclareModuleInfoRecipe,$m)))
-endif
+
 
 ALL_TARGETS += $(GENSRC_TARGETS)
 
@@ -752,9 +751,7 @@ else
   # Skip modules that do not have java source.
   # When creating a BUILDJDK, the java compilation has already been done by the
   # normal build and copied in.
-  ifneq ($(CREATING_BUILDJDK), true)
     $(foreach m, $(filter $(JAVA_MODULES), $(LIBS_MODULES)), $(eval $m-libs: $m-java))
-  endif
 
   # Declare dependencies from all other <module>-lib to java.base-lib
   $(foreach t, $(filter-out java.base-libs, $(LIBS_TARGETS)), \

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -108,6 +108,18 @@ ALL_TARGETS += generate-exported-symbols
 #
 # When creating a BUILDJDK, the java targets have already been built and copied
 # into the buildjdk so no need to generate sources.
+ifneq ($(CREATING_BUILDJDK), true)
+  GENERATE_BUILDJDK_SOURCES := true
+endif
+
+# Windows AArch64 is built by cross compiling. Therefore, the buildjdk sources
+# need to be generated unconditionally to avoid a 'No rule to make target
+# windows/conf/tzmappings' error
+ifeq ($(OPENJDK_TARGET_OS)+$(COMPILE_TYPE), windows+cross)
+  GENERATE_BUILDJDK_SOURCES := true
+endif
+
+ifeq ($(GENERATE_BUILDJDK_SOURCES), true)
   $(eval $(call DeclareRecipesForPhase, GENSRC, \
       TARGET_SUFFIX := gensrc-src, \
       FILE_PREFIX := Gensrc, \
@@ -141,7 +153,7 @@ ALL_TARGETS += generate-exported-symbols
   endef
 
   $(foreach m, $(GENSRC_MODULEINFO_MODULES), $(eval $(call DeclareModuleInfoRecipe,$m)))
-
+endif
 
 ALL_TARGETS += $(GENSRC_TARGETS)
 
@@ -751,7 +763,9 @@ else
   # Skip modules that do not have java source.
   # When creating a BUILDJDK, the java compilation has already been done by the
   # normal build and copied in.
+  ifeq ($(GENERATE_BUILDJDK_SOURCES), true)
     $(foreach m, $(filter $(JAVA_MODULES), $(LIBS_MODULES)), $(eval $m-libs: $m-java))
+  endif
 
   # Declare dependencies from all other <module>-lib to java.base-lib
   $(foreach t, $(filter-out java.base-libs, $(LIBS_TARGETS)), \

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -110,13 +110,13 @@ ALL_TARGETS += generate-exported-symbols
 # into the buildjdk so no need to generate sources.
 ifneq ($(CREATING_BUILDJDK), true)
   GENERATE_BUILDJDK_SOURCES := true
-endif
-
-# Windows AArch64 is built by cross compiling. Therefore, the buildjdk sources
-# need to be generated unconditionally to avoid a 'No rule to make target
-# windows/conf/tzmappings' error
-ifeq ($(OPENJDK_TARGET_OS)+$(COMPILE_TYPE), windows+cross)
+else ifeq ($(OPENJDK_TARGET_OS)+$(COMPILE_TYPE), windows+cross)
+ # Windows AArch64 is built by cross compiling. Therefore, the buildjdk sources
+ # need to be generated unconditionally to avoid a 'No rule to make target
+ # windows/conf/tzmappings' error
   GENERATE_BUILDJDK_SOURCES := true
+else
+  GENERATE_BUILDJDK_SOURCES :=
 endif
 
 ifeq ($(GENERATE_BUILDJDK_SOURCES), true)

--- a/ms-patches/win-aarch64-build-error-8329348.yml
+++ b/ms-patches/win-aarch64-build-error-8329348.yml
@@ -1,0 +1,12 @@
+title: Fix Windows AArch64 jdk11u build error
+- work_item: 1993805
+- jbs_bug: JDK-8329348
+- author: swesonga
+- owner: swesonga
+- contributors:
+- details:
+  - Fixes the Windows AArch64 jdk11u build error 'No rule to make target .../windows/conf/tzmappings'.
+  - The root cause of this error is that the GENSRC_TARGETS are not built.
+  - This fix removes checks for CREATING_BUILDJDK to ensure that the GENSRC_TARGETS are built unconditionally.
+  - These checks were also found to be incorrect in https://bugs.openjdk.org/browse/JDK-8217739
+- release_note:


### PR DESCRIPTION
Fixes the Windows AArch64 jdk11u build error 'No rule to make target .../windows/conf/tzmappings'.
The root cause of this error is that the GENSRC_TARGETS are not built.
This fix ensures that the GENSRC_TARGETS are built unconditionally for Windows AArch64.
The existing checks for CREATING_BUILDJDK were also found to be incorrect in https://bugs.openjdk.org/browse/JDK-8217739