### PR TITLE
Add missing 'static' keyword to inner class

### DIFF
--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
@@ -59,7 +59,7 @@ public class TestInvalidLocation {
         }
     }
 
-    class Class1 {
+    static class Class1 {
         static Class0 Class1_sfield0 = new Class0();
     }
 }


### PR DESCRIPTION
Relates to this work item: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2032312/

The version of java used to run the test requires the inner class to be 'static' so that its field can also be 'static'.

Tested locally on Linux x86_64