### PR TITLE
Remove calls to test APIs unavailable in jdk11u

### DIFF
--- a/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
@@ -66,7 +67,7 @@ public class TestAvailableProcessors {
         OutputAnalyzer outputAnalyzer = new OutputAnalyzer(processBuilder.start());
         outputAnalyzer.shouldHaveExitValue(0);
         outputAnalyzer.shouldContain(osVersionMessage);
-        List<String> lines = outputAnalyzer.stdoutAsLines();
+        List<String> lines = asLines(outputAnalyzer.getStdout());
 
         String osVersion = null;
         for (var line: lines) {
@@ -78,6 +79,10 @@ public class TestAvailableProcessors {
 
         System.out.println("Found OS version: " + osVersion);
         return osVersion;
+    }
+
+    private static List<String> asLines(String buffer) {
+        return Arrays.asList(buffer.split("\\R"));
     }
 
     private static boolean getSchedulesAllProcessorGroups(boolean isWindowsServer) throws IOException {
@@ -115,7 +120,7 @@ public class TestAvailableProcessors {
     private static OutputAnalyzer getAvailableProcessorsOutput(boolean productFlagEnabled) throws IOException {
         String productFlag = productFlagEnabled ? "-XX:+UseAllWindowsProcessorGroups" : "-XX:-UseAllWindowsProcessorGroups";
 
-        ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
             new String[] {productFlag, "GetAvailableProcessors"}
         );
 
@@ -128,7 +133,7 @@ public class TestAvailableProcessors {
 
     private static int getAvailableProcessors(OutputAnalyzer outputAnalyzer) {
         int runtimeAvailableProcs = 0;
-        List<String> output = outputAnalyzer.stdoutAsLines();
+        List<String> output = asLines(outputAnalyzer.getStdout());
 
         for (var line: output) {
             if (line.startsWith(runtimeAvailableProcessorsMessage)) {
@@ -188,7 +193,7 @@ public class TestAvailableProcessors {
         boolean isWindowsServer = false;
         var processorGroupSizes = new HashSet<Integer>();
 
-        List<String> lines = outputAnalyzer.stdoutAsLines();
+        List<String> lines = asLines(outputAnalyzer.getStdout());
 
         for (var line: lines) {
             if (line.startsWith(totalProcessorCountMessage)) {

--- a/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/windows/TestAvailableProcessors.java
@@ -28,7 +28,6 @@
  * @requires os.family == "windows"
  * @summary This test verifies that OpenJDK can use all available
  *          processors on Windows 11/Windows Server 2022 and later.
- * @requires vm.flagless
  * @library /test/lib
  * @compile GetAvailableProcessors.java
  * @run testng TestAvailableProcessors


### PR DESCRIPTION
Some of the usage of the OutputAnalyzer in the TestAvailableProcessors class depends on APIs that are not in the jdk11u OutputAnalyzer. This PR fixes these compilation errors in jdk11u, similar to the jdk17u fix in https://github.com/microsoft/openjdk-jdk17u/pull/30

The backport used the jdk21u APIs introduced in https://github.com/openjdk/jdk21u/commit/262cacb2385af4e0e2ee3a4e1f763b68e3101f28#diff-13897cfb2b23f2a1424c9874bdb40f563b56cd01d2b560ace927fe240d15a5a9 and should have used the previous OutputAnalyzer.
The backport also shouldn't have the fix for https://bugs.openjdk.org/browse/JDK-8315097

The difference between the jdk17u fix in https://github.com/microsoft/openjdk-jdk17u/pull/30 and this change is the extra commit https://github.com/microsoft/openjdk-jdk11u/commit/2f0a8ac991ed239050f535f8c62fcfc229dd972f required in jdk11u to get the test to run (otherwise it will not be selected to run).