### PR TITLE
Use armasm64.exe as the assembler for Windows aarch64

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -117,6 +117,12 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
         JVM_BASIC_ASFLAGS+=" $OS_CFLAGS \
             -DMAC_OS_X_VERSION_MAX_ALLOWED=$MACOSX_VERSION_MAX_NODOTS"
     fi
+  elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+    if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+      JVM_BASIC_ASFLAGS="-nologo"
+    else
+      JVM_BASIC_ASFLAGS="-nologo -c"
+    fi
   fi
 ])
 

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -748,8 +748,16 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
   elif test "x$TOOLCHAIN_TYPE" != xmicrosoft; then
     AS="$CC -c"
   else
-    # On windows, the assember is "ml.exe"
-    UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml)
+    if test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+      # On Windows aarch64, the assembler is "armasm64.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, armasm64)
+    elif test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
+      # On Windows x64, the assembler is "ml64.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
+    else
+      # otherwise, the assember is "ml.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml)
+    fi
   fi
   AC_SUBST(AS)
 

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -450,15 +450,25 @@ define SetupCompileNativeFileBody
           # Keep as much as possible on one execution line for best performance
           # on Windows. No need to save exit code from compilation since
           # pipefail is always active on Windows.
-	  $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
-	      $$($1_COMPILER) -showIncludes $$($1_COMPILE_OPTIONS))) \
-	      | $(TR) -d '\r' | $(GREP) -v -e "^Note: including file:" \
-	          -e "^$$($1_FILENAME)$$$$" || test "$$$$?" = "1" ; \
-	  $(ECHO) $$@: \\ > $$($1_DEPS_FILE) ; \
-	  $(SED) $(WINDOWS_SHOWINCLUDE_SED_PATTERN) $$($1_OBJ).log \
-	      | $(SORT) -u >> $$($1_DEPS_FILE) ; \
-	  $(ECHO) >> $$($1_DEPS_FILE) ; \
-	  $(SED) $(DEPENDENCY_TARGET_SED_PATTERN) $$($1_DEPS_FILE) > $$($1_DEPS_TARGETS_FILE)
+          ifeq ($$(filter %.S, $$($1_FILENAME)), )
+	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
+	        $$($1_COMPILER) -showIncludes $$($1_COMPILE_OPTIONS))) \
+	        | $(TR) -d '\r' | $(GREP) -v -e "^Note: including file:" \
+	            -e "^$$($1_FILENAME)$$$$" || test "$$$$?" = "1" ; \
+	    $(ECHO) $$@: \\ > $$($1_DEPS_FILE) ; \
+	    $(SED) $(WINDOWS_SHOWINCLUDE_SED_PATTERN) $$($1_OBJ).log \
+	        | $(SORT) -u >> $$($1_DEPS_FILE) ; \
+	    $(ECHO) >> $$($1_DEPS_FILE) ; \
+	    $(SED) $(DEPENDENCY_TARGET_SED_PATTERN) $$($1_DEPS_FILE) > $$($1_DEPS_TARGETS_FILE)
+          else
+            # For assembler calls just create empty dependency lists
+	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
+	        $$($1_COMPILER) $$($1_FLAGS) \
+	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE))) \
+	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1" ; \
+	    $(ECHO) > $$($1_DEPS_FILE) ; \
+	    $(ECHO) > $$($1_DEPS_TARGETS_FILE)
+          endif
         endif
   endif
 endef

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -461,13 +461,11 @@ define SetupCompileNativeFileBody
 	    $(ECHO) >> $$($1_DEPS_FILE) ; \
 	    $(SED) $(DEPENDENCY_TARGET_SED_PATTERN) $$($1_DEPS_FILE) > $$($1_DEPS_TARGETS_FILE)
           else
-            # For assembler calls just create empty dependency lists
+            # For assembler calls just run the assembler; no dependency tracking needed
 	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
 	        $$($1_COMPILER) $$($1_FLAGS) \
 	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE))) \
-	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1" ; \
-	    $(ECHO) > $$($1_DEPS_FILE) ; \
-	    $(ECHO) > $$($1_DEPS_TARGETS_FILE)
+	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1"
           endif
         endif
   endif


### PR DESCRIPTION
This backport is a cherrypick of https://github.com/microsoft/openjdk-jdk17u/commit/e28eb2c286b7ebf975676a89f91f222698d31eb2 with modifications to `make/common/NativeCompilation.gmk`, specifically removal of the `-Ta` argument and the addition of the `.S` filter block introduced in [8264188: Improve handling of assembly files in the JDK](https://bugs.openjdk.org/browse/JDK-8264188)