### PR TITLE
2. Windows AArch64 safefetch implementation should not use structured exception handling

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2363,6 +2363,40 @@ LONG WINAPI Handle_FLT_Exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
 }
 #endif
 
+#if defined(_M_ARM64)
+
+// SafeFetch handling, static assembly style:
+//
+// SafeFetch32 and SafeFetchN are implemented via static assembly
+// and live in os_cpu/xx_xx/safefetch_xx_xx.S
+
+extern "C" char _SafeFetch32_continuation[];
+extern "C" char _SafeFetch32_fault[];
+
+#ifdef _LP64
+extern "C" char _SafeFetchN_continuation[];
+extern "C" char _SafeFetchN_fault[];
+#endif // _LP64
+
+bool handle_safefetch(int exception_code, address pc, void* context) {
+  CONTEXT* ctx = (CONTEXT*)context;
+  if (exception_code == EXCEPTION_ACCESS_VIOLATION && ctx != nullptr) {
+    if (pc == (address)_SafeFetch32_fault) {
+      os::win32::context_set_pc(ctx, (address)_SafeFetch32_continuation);
+      return true;
+    }
+#ifdef _LP64
+    if (pc == (address)_SafeFetchN_fault) {
+      os::win32::context_set_pc(ctx, (address)_SafeFetchN_continuation);
+      return true;
+    }
+#endif
+  }
+  return false;
+}
+
+#endif // _M_ARM64
+
 static inline void report_error(Thread* t, DWORD exception_code,
                                 address addr, void* siginfo, void* context) {
   VMError::report_and_die(t, exception_code, addr, siginfo, context);
@@ -2386,10 +2420,16 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 #endif
   Thread* t = Thread::current_or_null_safe();
 
+#if defined(_M_ARM64)
+  if (handle_safefetch(exception_code, pc, (void*)exceptionInfo->ContextRecord)) {
+    return EXCEPTION_CONTINUE_EXECUTION;
+  }
+#else
   // Handle SafeFetch32 and SafeFetchN exceptions.
   if (StubRoutines::is_safefetch_fault(pc)) {
     return Handle_Exception(exceptionInfo, StubRoutines::continuation_for_safefetch_fault(pc));
   }
+#endif
 
 #ifndef _WIN64
   // Execution protection violation - win32 running on AMD64 only

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -128,6 +128,7 @@ public:
     _thread_ptr_offset = offset;
   }
   static inline int get_thread_ptr_offset() { return _thread_ptr_offset; }
+  static void context_set_pc(CONTEXT* uc, address pc);
 };
 
 static void write_memory_serialize_page_with_handler(JavaThread* thread) {

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -103,6 +103,10 @@ frame os::fetch_frame_from_context(const void* ucVoid) {
   return frame(sp, fp, epc.pc());
 }
 
+void os::win32::context_set_pc(CONTEXT* uc, address pc) {
+  uc->Pc = (intptr_t)pc;
+}
+
 bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
         struct _EXCEPTION_POINTERS* exceptionInfo, address pc, frame* fr) {
   PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;

--- a/src/hotspot/os_cpu/windows_aarch64/safefetch_windows_aarch64.S
+++ b/src/hotspot/os_cpu/windows_aarch64/safefetch_windows_aarch64.S
@@ -1,0 +1,65 @@
+;
+; Copyright (c) 2022 SAP SE. All rights reserved.
+; Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
+; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+;
+; This code is free software; you can redistribute it and/or modify it
+; under the terms of the GNU General Public License version 2 only, as
+; published by the Free Software Foundation.
+;
+; This code is distributed in the hope that it will be useful, but WITHOUT
+; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+; version 2 for more details (a copy is included in the LICENSE file that
+; accompanied this code).
+;
+; You should have received a copy of the GNU General Public License version
+; 2 along with this work; if not, write to the Free Software Foundation,
+; Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+;
+; Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+; or visit www.oracle.com if you need additional information or have any
+; questions.
+;
+
+    ; Support for int SafeFetch32(int* address, int defaultval);
+    ;
+    ;  x0 : address
+    ;  w1 : defaultval
+
+    ; needed to align function start to 4 byte
+    ALIGN  4
+    EXPORT _SafeFetch32_fault
+    EXPORT _SafeFetch32_continuation
+    EXPORT SafeFetch32_impl
+    AREA safefetch_text, CODE
+
+SafeFetch32_impl
+_SafeFetch32_fault
+    ldr w0, [x0]
+    ret
+
+_SafeFetch32_continuation
+    mov      x0, x1
+    ret
+
+    ; Support for intptr_t SafeFetchN(intptr_t* address, intptr_t defaultval);
+    ;
+    ;  x0 : address
+    ;  x1 : defaultval
+
+    ALIGN  4
+    EXPORT _SafeFetchN_fault
+    EXPORT _SafeFetchN_continuation
+    EXPORT SafeFetchN_impl
+
+SafeFetchN_impl
+_SafeFetchN_fault
+    ldr      x0, [x0]
+    ret
+
+_SafeFetchN_continuation
+    mov      x0, x1
+    ret
+
+    END


### PR DESCRIPTION
This backport is a cherry-pick of https://github.com/microsoft/openjdk-jdk17u/commit/f9ff7b8efc2b6b3181e164141a973998231da5af with these changes:

- The `handle_safefetch` function in safefetch_static_windows.cpp is inlined in os_windows.cpp since there are no other specialized os/cpu implementations
- There is no src/hotspot/share/runtime/safefetch.hpp file in jdk11u and therefore no corresponding change in this PR