### PR TITLE
Fix build error caused by missing function signature update

### DIFF
--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.hpp
@@ -68,7 +68,7 @@
 #ifdef AMD64
 #define PLATFORM_PRINT_NATIVE_STACK 1
 static bool platform_print_native_stack(outputStream* st, const void* context,
-                                        char *buf, int buf_size);
+                                        char *buf, int buf_size, address& lastpc);
 #endif
 
 #endif // OS_CPU_WINDOWS_X86_VM_OS_WINDOWS_X86_HPP

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -912,7 +912,7 @@ class os: AllStatic {
 #ifndef PLATFORM_PRINT_NATIVE_STACK
   // No platform-specific code for printing the native stack.
   static bool platform_print_native_stack(outputStream* st, const void* context,
-                                          char *buf, int buf_size) {
+                                          char *buf, int buf_size, address& lastpc) {
     return false;
   }
 #endif

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -668,7 +668,8 @@ extern "C" JNIEXPORT void pns(void* sp, void* fp, void* pc) { // print native st
 extern "C" JNIEXPORT void pns2() { // print native stack
   Command c("pns2");
   static char buf[O_BUFLEN];
-  if (os::platform_print_native_stack(tty, NULL, buf, sizeof(buf))) {
+  address lastpc = NULL;
+  if (os::platform_print_native_stack(tty, NULL, buf, sizeof(buf), lastpc)) {
     // We have printed the native stack in platform-specific code,
     // so nothing else to do in this case.
   } else {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -713,7 +713,8 @@ void VMError::report(outputStream* st, bool _verbose) {
   STEP("printing native stack")
 
    if (_verbose) {
-     if (os::platform_print_native_stack(st, _context, buf, sizeof(buf))) {
+     address lastpc = NULL;
+     if (os::platform_print_native_stack(st, _context, buf, sizeof(buf), lastpc)) {
        // We have printed the native stack in platform-specific code
        // Windows/x64 needs special handling.
      } else {


### PR DESCRIPTION
Provide the lastpc argument introduced by https://bugs.openjdk.org/browse/JDK-8309613 (but not backported to jdk11u).

This fixes a build error introduced by backporting https://github.com/microsoft/openjdk-jdk17u/commit/88edfb5289c8f9a1b336e694f380b22c9f6500bf

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
