### PR TITLE
8253900: SA: wrong size computation when JVM was built without AOT

### DIFF
--- a/ms-patches/8253900-TestInstanceKlass.yml
+++ b/ms-patches/8253900-TestInstanceKlass.yml
@@ -1,0 +1,10 @@
+title: SA: wrong size computation when JVM was built without AOT
+- work_item: 3042210
+- jbs_bug: JDK-8253900
+- author: swesonga
+- owner: swesonga
+- contributors:
+ - swesonga
+- details:
+ - Backport fix for JDK-8253900
+- release_note: Fix wrong InstanceKlass size when JVM was built without AOT

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -234,6 +234,7 @@
   JVMTI_ONLY(nonstatic_field(MethodCounters,   _number_of_breakpoints,                        u2))                                   \
   nonstatic_field(MethodCounters,              _invocation_counter,                           InvocationCounter)                     \
   nonstatic_field(MethodCounters,              _backedge_counter,                             InvocationCounter)                     \
+  AOT_ONLY(nonstatic_field(MethodCounters,     _method,                                       Method*))                              \
                                                                                                                                      \
   nonstatic_field(MethodData,                  _size,                                         int)                                   \
   nonstatic_field(MethodData,                  _method,                                       Method*)                               \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -304,6 +304,7 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
   JVMTI_ONLY(nonstatic_field(MethodCounters,   _number_of_breakpoints,                        u2))                                   \
   nonstatic_field(MethodCounters,              _invocation_counter,                           InvocationCounter)                     \
   nonstatic_field(MethodCounters,              _backedge_counter,                             InvocationCounter)                     \
+  AOT_ONLY(nonstatic_field(MethodCounters,     _method,                                       Method*))                              \
   nonstatic_field(Method,                      _constMethod,                                  ConstMethod*)                          \
   nonstatic_field(Method,                      _method_data,                                  MethodData*)                           \
   nonstatic_field(Method,                      _method_counters,                              MethodCounters*)                       \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -310,6 +310,11 @@ public class InstanceKlass extends Klass {
   }
 
   public boolean hasStoredFingerprint() {
+    // has_stored_fingerprint() @ instanceKlass.cpp can return true only if INCLUDE_AOT is
+    // set during compilation.
+    if (!VM.getVM().hasAOT()) {
+      return false;
+    }
     return shouldStoreFingerprint() || isShared();
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -88,6 +88,8 @@ public class VM {
   private FileMapInfo  fileMapInfo;
   private Bytes        bytes;
 
+  /** Flag indicating if AOT is enabled in the build */
+  private boolean      hasAOT;
   /** Flag indicating if JVMTI support is included in the build */
   private boolean      isJvmtiSupported;
   /** Flags indicating whether we are attached to a core, C1, or C2 build */
@@ -401,6 +403,16 @@ public class VM {
 
     stackBias    = db.lookupIntConstant("STACK_BIAS").intValue();
     invocationEntryBCI = db.lookupIntConstant("InvocationEntryBci").intValue();
+
+    // We infer AOT if _method @ methodCounters is declared.
+    {
+      Type type = db.lookupType("MethodCounters");
+      if (type.getField("_method", false, false) == null) {
+        hasAOT = false;
+      } else {
+        hasAOT = true;
+      }
+    }
 
     // We infer the presence of JVMTI from the presence of the InstanceKlass::_breakpoints field.
     {
@@ -784,6 +796,11 @@ public class VM {
   /** Returns true if this is a isBigEndian, false otherwise */
   public boolean isBigEndian() {
     return isBigEndian;
+  }
+
+  /** Returns true if AOT is enabled, false otherwise */
+  public boolean hasAOT() {
+    return hasAOT;
   }
 
   /** Returns true if JVMTI is supported, false otherwise */

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -199,8 +199,6 @@ serviceability/sa/TestDefaultMethods.java 8193639 solaris-all
 serviceability/sa/TestG1HeapRegion.java 8193639 solaris-all
 serviceability/sa/TestHeapDumpForInvokeDynamic.java 8193639 solaris-all
 serviceability/sa/TestHeapDumpForLargeArray.java 8193639 solaris-all
-serviceability/sa/TestInstanceKlassSize.java 8193639 solaris-all
-serviceability/sa/TestInstanceKlassSizeForInterface.java 8193639 solaris-all
 serviceability/sa/TestIntConstant.java 8193639 solaris-all
 serviceability/sa/TestJhsdbJstackLock.java 8193639 solaris-all
 serviceability/sa/TestJmapCore.java 8193639,8267433 solaris-all,macosx-x64

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
@@ -137,7 +137,7 @@ public class TestInstanceKlassSize {
                     if (s.contains(instanceKlassName)) {
                        Asserts.assertTrue(
                           s.contains(jcmdInstanceKlassSize),
-                          "The size computed by SA for" +
+                          "The size computed by SA for " +
                           instanceKlassName + " does not match.");
                     }
                 }


### PR DESCRIPTION
Backport fix for JDK-8253900.
This fixes test failures in TestInstanceKlassSize.java

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
