### PR TITLE
Add patch for 8253900 to the patch index

### DIFF
--- a/ms-patches/microsoft-patch-index.yml
+++ b/ms-patches/microsoft-patch-index.yml
@@ -35,6 +35,7 @@ active-patches:
   - ms-patches/processor-api
   - ms-patches/multiple-logins
   - ms-patches/msys2-fixes
+  - ms-patches/8253900-TestInstanceKlass
 
 ## Upstreamed Patches
 # Patches that we are no longer applying to our releases, as they


### PR DESCRIPTION
Add fix from [8253900: SA: wrong size computation when JVM was built without AOT](https://github.com/microsoft/openjdk-jdk11u/pull/79) to the index

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
